### PR TITLE
Use new format instead of legacy

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,7 +21,7 @@ export default [
       },
       {
         file: "dist/current.js",
-        format: "es",
+        format: "esm",
       },
     ],
     plugins: [resolve(), typescript(), filesize(), minify()],


### PR DESCRIPTION
"es" and "esm" are both formats for ECMAScript modules.

"es" is a legacy format that was used before the introduction of the "esm" format. It is a simple format that does not support all the features of modern ES modules. For example, it does not support dynamic imports.

"esm" is a newer and more advanced format that is designed to work with modern ES modules. It supports all the features of ES modules, including dynamic imports, export renaming, and export namespace objects. It is the recommended format for building modern JavaScript libraries and applications.