### PR TITLE
Introduce `config.prefix` to specify a meta-name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,47 @@ Current.foo
 // => {}
 ```
 
+## Configuration
+
+#### Custom Prefix
+
+The `prefix` property on `config` can be used to customize the prefix used to lookup the `<meta>` tags.
+
+```js
+import { config } from "current.js"
+config.prefix = "config"
+```
+
+```html
+<meta name="current-environment" content="development">
+<meta name="config-environment" content="production">
+```
+
+Calling `Current.environment` would now look for the meta tag with the `config-environment` name.
+
+```js
+Current.environment
+// => "production"
+```
+
+
+#### No Prefix
+
+You can also configure `current.js` to use no `prefix` if you set the `prefix` to `null`.
+
+```js
+import { config } from "current.js"
+config.prefix = null
+```
+
+```html
+<meta name="current-environment" content="development">
+<meta name="environment" content="production">
+```
+
+Calling `Current.environment` would also return `"production"` in this case.
+
+
 ## Development
 
 To run the test runner:

--- a/src/current.ts
+++ b/src/current.ts
@@ -6,7 +6,7 @@ type CurrentValue = string | CurrentValueObject
 const currentProxy = {
   get(_target: object, propertyName: string): CurrentValue {
     const result: CurrentValueObject = {}
-    const prefix = `current-${propertyName}`
+    const prefix = `${config.prefix}-${propertyName}`
 
     const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${prefix}]`)
     const startsWith = Array.from(document.head.querySelectorAll<HTMLMetaElement>(`meta[name^=${prefix}-]`))
@@ -26,3 +26,6 @@ const currentProxy = {
 }
 
 export const Current = new Proxy({}, currentProxy)
+export const config = {
+  prefix: "current"
+}

--- a/src/current.ts
+++ b/src/current.ts
@@ -6,14 +6,15 @@ type CurrentValue = string | CurrentValueObject
 const currentProxy = {
   get(_target: object, propertyName: string): CurrentValue {
     const result: CurrentValueObject = {}
-    const prefix = `${config.prefix}-${propertyName}`
+    const prefix = config.prefix ? `${config.prefix}-` : ""
+    const metaName = `${prefix}${propertyName}`
 
-    const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${prefix}]`)
-    const startsWith = Array.from(document.head.querySelectorAll<HTMLMetaElement>(`meta[name^=${prefix}-]`))
+    const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${metaName}]`)
+    const startsWith = Array.from(document.head.querySelectorAll<HTMLMetaElement>(`meta[name^=${metaName}-]`))
 
     if (startsWith.length > 0) {
       for (const { name, content } of startsWith) {
-        const key = camelize(name.slice(prefix.length + 1))
+        const key = camelize(name.slice(metaName.length + 1))
         if (result[key]) continue
         result[key] = content
       }
@@ -27,5 +28,5 @@ const currentProxy = {
 
 export const Current = new Proxy({}, currentProxy)
 export const config = {
-  prefix: "current"
+  prefix: "current",
 }

--- a/test/current/current.test.js
+++ b/test/current/current.test.js
@@ -1,11 +1,12 @@
 import { assert } from "@open-wc/testing"
 import { meta, metaCleanup } from "../test_helpers"
 
-import { Current } from "../../"
+import { Current, config } from "../../"
 
 describe("Current.js", () => {
   afterEach(() => {
     metaCleanup()
+    config.prefix = "current"
   })
 
   context("undefined", () => {
@@ -127,6 +128,17 @@ describe("Current.js", () => {
       assert.equal(Current.user.id, "Current ID")
       assert.equal(Current.user.name, "Current Name")
       assert.equal(Current.user.email, "Current Email")
+    })
+  })
+
+  context("with custom prefix", () => {
+    it("should handle custom prefix", async () => {
+      await meta(`<meta name="current-environment" content="development">`)
+      await meta(`<meta name="config-environment" content="production">`)
+
+      assert.equal(Current.environment, "development")
+      config.prefix = "config"
+      assert.equal(Current.environment, "production")
     })
   })
 })

--- a/test/current/current.test.js
+++ b/test/current/current.test.js
@@ -131,13 +131,22 @@ describe("Current.js", () => {
     })
   })
 
-  context("with custom prefix", () => {
+  context("with prefix config", () => {
     it("should handle custom prefix", async () => {
       await meta(`<meta name="current-environment" content="development">`)
       await meta(`<meta name="config-environment" content="production">`)
 
       assert.equal(Current.environment, "development")
       config.prefix = "config"
+      assert.equal(Current.environment, "production")
+    })
+
+    it("should handle no prefix", async () => {
+      await meta(`<meta name="current-environment" content="development">`)
+      await meta(`<meta name="environment" content="production">`)
+
+      assert.equal(Current.environment, "development")
+      config.prefix = null
       assert.equal(Current.environment, "production")
     })
   })


### PR DESCRIPTION
This pull request allows the user to customize the prefix used for looking up the `<meta>` tags. 

The `prefix` property on `config` can be used to customize the prefix. If one would want to use `config-*` meta attributes, they could configure it like:

```js
import { config } from "current.js"
config.prefix = "config"
```

```html
<meta name="current-environment" content="development">
<meta name="config-environment" content="production">
```

Calling `Current.environment` would now return `"production"`.

You can also configure to use no `prefix`, like:

```js
import { config } from "current.js"
config.prefix = null
```

```html
<meta name="current-environment" content="development">
<meta name="environment" content="production">
```

Calling `Current.environment` would also return `"production"` in this case.