### PR TITLE
Only lookup exact match if there are no startsWith matches

### DIFF
--- a/src/current.ts
+++ b/src/current.ts
@@ -17,12 +17,11 @@ const currentProxy = {
         if (result[key]) return
         result[key] = content
       })
-    } else {
-      const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${metaName}]`)
-      if (exact) return exact.content
+      return result
     }
 
-    return result
+    const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${metaName}]`)
+    return (exact && exact.content) || result
   },
 }
 

--- a/src/current.ts
+++ b/src/current.ts
@@ -9,17 +9,17 @@ const currentProxy = {
     const prefix = config.prefix ? `${config.prefix}-` : ""
     const metaName = `${prefix}${propertyName}`
 
-    const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${metaName}]`)
-    const startsWith = Array.from(document.head.querySelectorAll<HTMLMetaElement>(`meta[name^=${metaName}-]`))
+    const startsWith = document.head.querySelectorAll<HTMLMetaElement>(`meta[name^=${metaName}-]`)
 
     if (startsWith.length > 0) {
-      for (const { name, content } of startsWith) {
+      startsWith.forEach(({ name, content }) => {
         const key = camelize(name.slice(metaName.length + 1))
-        if (result[key]) continue
+        if (result[key]) return
         result[key] = content
-      }
-    } else if (exact) {
-      return exact.content
+      })
+    } else {
+      const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${metaName}]`)
+      if (exact) return exact.content
     }
 
     return result

--- a/src/current.ts
+++ b/src/current.ts
@@ -21,7 +21,7 @@ const currentProxy = {
     }
 
     const exact = document.head.querySelector<HTMLMetaElement>(`meta[name=${metaName}]`)
-    return (exact && exact.content) || result
+    return exact ? exact.content : result
   },
 }
 


### PR DESCRIPTION
Optimize use of calls that doesn't need to run until they do - like move `exact` querySelector to the else clause and remove `Array.from`, since Node Lists have `forEach` method built-in.

This shaves off 2 bytes from bundle and minified sizes and 4-5 bytes when gzipped:

## Before

```
┌──────────────────────────────┐
│ Destination: dist/current.js │
│ Bundle Size:  452 B          │
│ Minified Size:  451 B        │
│ Gzipped Size:  314 B         │
└──────────────────────────────┘
┌──────────────────────────────────┐
│ Destination: dist/current.umd.js │
│ Bundle Size:  684 B              │
│ Minified Size:  683 B            │
│ Gzipped Size:  422 B             │
└──────────────────────────────────┘
```

## After

```
┌──────────────────────────────┐
│ Destination: dist/current.js │
│ Bundle Size:  450 B          │
│ Minified Size:  449 B        │
│ Gzipped Size:  309 B         │
└──────────────────────────────┘
┌──────────────────────────────────┐
│ Destination: dist/current.umd.js │
│ Bundle Size:  682 B              │
│ Minified Size:  681 B            │
│ Gzipped Size:  418 B             │
└──────────────────────────────────┘
```